### PR TITLE
Fix SSG patch.

### DIFF
--- a/packages/scap-security-guide/fixes-with-variables.patch
+++ b/packages/scap-security-guide/fixes-with-variables.patch
@@ -1,7 +1,7 @@
-diff --git a/packages/scap-security-guide/scap-security-guide/RHEL6/transforms/xccdf-addfixes.xslt b/packages/scap-security-guide/scap-security-guide/RHEL6/transforms/xccdf-addfixes.xslt
+diff --git a/RHEL6/transforms/xccdf-addfixes.xslt b/RHEL6/transforms/xccdf-addfixes.xslt
 index 26a14bd..810477e 100644
---- a/packages/scap-security-guide/scap-security-guide/RHEL6/transforms/xccdf-addfixes.xslt
-+++ b/packages/scap-security-guide/scap-security-guide/RHEL6/transforms/xccdf-addfixes.xslt
+--- a/RHEL6/transforms/xccdf-addfixes.xslt
++++ b/RHEL6/transforms/xccdf-addfixes.xslt
 @@ -18,7 +18,7 @@
          <xsl:if test="@rule=$rule_id">
            <xsl:element name="fix" namespace="http://checklists.nist.gov/xccdf/1.1">


### PR DESCRIPTION
The patch was generated relative to the CLIP repo instead of the package
dir.
