### PR TITLE
Fix logic error in chvt in kickstart

### DIFF
--- a/kickstart/clip-apache/clip-apache.ks
+++ b/kickstart/clip-apache/clip-apache.ks
@@ -268,7 +268,9 @@ dhclient
 #CONFIG-BUILD-PLACEHOLDER
 export PATH="/sbin:/usr/sbin:/usr/bin:/bin:/usr/local/bin"
 exec >/root/clip_post_install.log 2>&1
-if [ x"$CONFIG_BUILD_LIVE_MEDIA" != "xy" ]; then
+if [ x"$CONFIG_BUILD_LIVE_MEDIA" != "xy" ] \
+        && [ x"$CONFIG_BUILD_AWS" != "xy" ];
+then
         # Print the log to tty7 so that the user know what's going on
         tail -f /root/clip_post_install.log >/dev/tty7 &
         TAILPID=$!

--- a/kickstart/clip-minimal/clip-minimal.ks
+++ b/kickstart/clip-minimal/clip-minimal.ks
@@ -232,8 +232,8 @@ dhclient
 #CONFIG-BUILD-PLACEHOLDER
 export PATH="/sbin:/usr/sbin:/usr/bin:/bin:/usr/local/bin"
 exec >/root/clip_post_install.log 2>&1
-if [ x"$CONFIG_BUILD_LIVE_MEDIA" == "xy" ] \
-        || [ x"$CONFIG_BUILD_AWS" == "xy" ];
+if [ x"$CONFIG_BUILD_LIVE_MEDIA" != "xy" ] \
+        && [ x"$CONFIG_BUILD_AWS" != "xy" ];
 then
         # Print the log to tty7 so that the user know what's going on
         tail -f /root/clip_post_install.log >/dev/tty7 &

--- a/kickstart/clip-sftp-dropbox/clip-sftp-dropbox.ks
+++ b/kickstart/clip-sftp-dropbox/clip-sftp-dropbox.ks
@@ -227,11 +227,13 @@ dhclient
 #CONFIG-BUILD-PLACEHOLDER
 export PATH="/sbin:/usr/sbin:/usr/bin:/bin:/usr/local/bin"
 exec >/root/clip_post_install.log 2>&1
-if [ x"$CONFIG_BUILD_LIVE_MEDIA" != "xy" ]; then
-	# Print the log to tty7 so that the user know what's going on
-	tail -f /root/clip_post_install.log >/dev/tty7 &
-	TAILPID=$!
-	chvt 7
+if [ x"$CONFIG_BUILD_LIVE_MEDIA" != "xy" ] \
+        && [ x"$CONFIG_BUILD_AWS" != "xy" ];
+then
+        # Print the log to tty7 so that the user know what's going on
+        tail -f /root/clip_post_install.log >/dev/tty7 &
+        TAILPID=$!
+        chvt 7
 fi
 
 

--- a/kickstart/clip-vpn/clip-vpn.ks
+++ b/kickstart/clip-vpn/clip-vpn.ks
@@ -234,13 +234,13 @@ dhclient
 #CONFIG-BUILD-PLACEHOLDER
 export PATH="/sbin:/usr/sbin:/usr/bin:/bin:/usr/local/bin"
 exec >/root/clip_post_install.log 2>&1
-if [ x"$CONFIG_BUILD_LIVE_MEDIA" == "xy" ] \
-	|| [ x"$CONFIG_BUILD_AWS" == "xy" ];
+if [ x"$CONFIG_BUILD_LIVE_MEDIA" != "xy" ] \
+        && [ x"$CONFIG_BUILD_AWS" != "xy" ];
 then
-	# Print the log to tty7 so that the user know what's going on
-	tail -f /root/clip_post_install.log >/dev/tty7 &
-	TAILPID=$!
-	chvt 7
+        # Print the log to tty7 so that the user know what's going on
+        tail -f /root/clip_post_install.log >/dev/tty7 &
+        TAILPID=$!
+        chvt 7
 fi
 
 


### PR DESCRIPTION
using chvt when generating live media doesn't work.
We knew this and fixed it. Then we broke it when
doing the AWS work. It only manifests itself when
building from a real console, not in pseudo-terminals,
which is why it has gone unnoticed.