### PR TITLE
added scripts used to smoke test live and install isos with qemu

### DIFF
--- a/support/tests/media/disable-fips.sh
+++ b/support/tests/media/disable-fips.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# mount the vm disk image and disable fips mode in grub conf
+
+set -e
+
+usage() {
+  echo "usage: $0 DISK_IMG"
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+DISK_IMAGE=$1
+
+if [ ! -e "$DISK_IMAGE" ]; then
+  echo "error: disk image $DISK_IMAGE does not exist"
+  exit 1
+fi
+
+MOUNT_DIR=vm_root
+is_mounted=0
+is_partxed=0
+
+cleanup() {
+  if [ -e "$MOUNT_DIR" ]; then
+    if [ "$is_mounted" = 1 ]; then
+      umount $MOUNT_DIR
+    fi
+    rmdir $MOUNT_DIR
+  fi
+
+  if [ -n "$vg_name" ]; then
+    vgchange -an $vg_name
+  fi
+
+  if [ "$is_partxed" = 1 ]; then
+    kpartx -d $DISK_IMAGE
+  fi
+}
+trap cleanup EXIT
+
+# create block devices for partions on vm image
+partitions=$(kpartx -v -s -a $DISK_IMAGE | awk '{print $3}')
+is_partxed=1
+
+# allow devmapper to settle
+sleep 2
+
+is_first=1
+part_path=
+part_re=
+for p in $partitions; do
+  if [ $is_first = 1 ]; then
+    is_first=0
+    part_path="/dev/mapper/$p"
+    part_re="/dev/mapper/$p"
+  else
+    part_re="$part_re|/dev/mapper/$p"
+  fi
+done
+
+vg_name=$(pvs -S "pv_name=~$part_re" -o vg_name --noheadings | awk '{print $1}')
+if [ -z "$vg_name" ]; then
+  echo "error: failed to find logical volume group in vm disk image"
+  exit 1
+fi
+
+mkdir $MOUNT_DIR
+mount $part_path $MOUNT_DIR
+is_mounted=1
+
+grub_conf_file=$MOUNT_DIR/grub2/grub.cfg
+if [ ! -e $grub_conf_file ]; then
+  echo "error: can't disable fips mode because grub.cfg not found"
+  exit 1
+else
+  sed -i -e 's/fips=1/fips=0/g' $grub_conf_file
+fi

--- a/support/tests/media/qemu-install-iso.sh
+++ b/support/tests/media/qemu-install-iso.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+########
+# expect script to smoke test CLIP install ISO
+# by: booting ISO with qemu, installing, rebooting
+
+
+usage() {
+  echo "usage: $0 ISO_PATH DISK_IMG"
+}
+
+if [ $# -ne 2 ]; then
+  usage
+  exit 1
+fi
+
+ISO_PATH="$1"
+DISK_IMAGE="$2"
+
+if [ ! -e "$ISO_PATH" ]; then
+  usage
+  echo "missing ISO_PATH $ISO_PATH"
+  exit 1
+fi
+
+if [ ! -e "$DISK_IMAGE" ]; then
+  usage
+  echo "missing DISK_IMG $DISK_IMAGE"
+  exit 1
+fi
+
+/usr/bin/expect -f - <<EOF
+set timeout 10
+
+# boot install iso and wait for installation to complete.
+spawn /usr/libexec/qemu-kvm -boot order=d -cdrom $ISO_PATH -m 1024 -nographic -vga none -device sga -hda $DISK_IMAGE -no-reboot -device virtio-rng-pci -enable-fips
+
+send_user "waiting for boot menu\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "Press Tab for full configuration options on menu items" {
+    send_user "pressing tab to edit boot arguments\n"
+    send -- "	"
+  }
+}
+
+send_user "waiting to edit boot arguments\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "vmlinuz" {
+    send_user "adding console=ttyS0 to boot arguments\n"
+    send -- " console=ttyS0\r"
+  }
+}
+
+set timeout 18000
+expect {
+  timeout { send_user "install did not complete in 5 hours"; exit 1 }
+  eof { send_user "got eof on install step" }
+  "reboot" { send_user "got reboot message" }
+}
+
+wait
+
+# first boot after installation.  reboot occurs because of policy relabel.
+spawn /usr/libexec/qemu-kvm -boot order=c -m 1024 -nographic -vga none -device sga -hda $DISK_IMAGE -no-reboot -device virtio-rng-pci -enable-fips
+
+set timeout 18000
+expect {
+  timeout { send_user "first boot did not complete in 5 hours"; exit 1 }
+  eof { send_user "got eof on first boot step" }
+  "Restarting system" { send_user "got reboot message" }
+}
+
+wait
+EOF

--- a/support/tests/media/qemu-login.sh
+++ b/support/tests/media/qemu-login.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+########
+# expect script to smoke test CLIP install ISO
+# by: booting installed VM with qemu,
+# logging in as toor, and running shutdown
+
+
+usage() {
+  echo "usage: $0 DISK_IMG"
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+DISK_IMAGE="$1"
+
+if [ ! -e "$DISK_IMAGE" ]; then
+  echo "error: missing disk image $DISK_IMAGE"
+  exit 1
+fi
+
+/usr/bin/expect -f - <<EOF
+# first full boot
+spawn /usr/libexec/qemu-kvm -boot order=c -m 1024 -nographic -vga none -device sga -hda $DISK_IMAGE -no-reboot -device virtio-rng-pci -enable-fips
+
+set timeout 300
+send_user "waiting for login prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "login: " {
+    sleep 1
+    send_user "sending username\n"
+    send -- "toor\r"
+  }
+}
+
+set timeout 10
+send_user "waiting for password prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "Password: " {
+    sleep 1
+    send_user "sending password\n"
+    send -- "neutronbass\r"
+  }
+}
+
+send_user "waiting for password change prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  -re "You are required to change your password immediately.*current.*password: " {
+    sleep 1
+    send_user "sending password again"
+    send -- "neutronbass\r"
+  }
+}
+
+send_user "waiting for new password prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "New password: " {
+    sleep 1
+    send_user "sending new password"
+    send -- "1234qwer!@#\\\$QWER\r"
+  }
+}
+
+send_user "waiting for new password confirmation prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "Retype new password: " {
+    sleep 1
+    send_user "sending new password confirmation"
+    send -- "1234qwer!@#\\\$QWER\r"
+  }
+}
+
+send_user "waiting for command prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "$ " {
+    send_user "sending id command\n"
+    send -- "id -Z\r"
+  }
+}
+
+send_user "waiting for command prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "$ " {
+    send_user "sending shutdown command\n"
+    send -- "sudo shutdown -h now\r"
+  }
+}
+
+send_user "waiting for password request from sudo\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "password for toor:" {
+    sleep 1
+    send_user "sending password\n"
+    send -- "1234qwer!@#\\\$QWER\r"
+  }
+}
+
+set timeout 300
+send_user "waiting for power down\n"
+expect {
+  eof { send_user "got eof\n" }
+  timeout { send_user "\nerror: timeout while waiting for power off\n"; exit 1 }
+  "Powering off." { send_user "got powering off message\n" }
+}
+
+wait
+EOF

--- a/support/tests/media/qemu-test-inst-iso.sh
+++ b/support/tests/media/qemu-test-inst-iso.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+########
+# expect script to smoke test CLIP install ISO
+# by: booting ISO with qemu, installing, rebooting,
+# logging in as toor, and running shutdown
+
+DISK_IMAGE=drive.img
+
+usage() {
+  echo "usage: $0 ISO_PATH"
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+if [ -e "$DISK_IMAGE" ]; then
+  echo "error: disk image $DISK_IMAGE exists.  please move or remove it to continue."
+  exit 1
+fi
+
+ISO_PATH="$1"
+
+if [ ! -e "$ISO_PATH" ]; then
+  usage
+  echo "missing ISO_PATH $ISO_PATH"
+  exit 1
+fi
+
+base_dir=$(dirname $0)
+
+dd if=/dev/zero of=$DISK_IMAGE bs=1M count=0 seek=20000
+
+# boot the install iso and wait for installation to complete
+$base_dir/qemu-install-iso.sh $ISO_PATH $DISK_IMAGE
+
+# qemu vm with full virt fails fips mode (fips_ecdsa_selftest) for
+# some reason
+if [ -z "$DISABLE_FIPS" ]; then
+  if virt-host-validate | grep -q 'QEMU: Checking for hardware virtualization.*PASS'; then
+    DISABLE_FIPS=n
+  else
+    echo "warning: disabling fips mode because hardware virtualization is not supported on this system"
+    DISABLE_FIPS=y
+  fi
+fi
+if [ "$DISABLE_FIPS" = "y" ]; then
+  sudo $base_dir/disable-fips.sh $DISK_IMAGE
+fi
+
+# boot the installed vm and run login test
+$base_dir/qemu-login.sh $DISK_IMAGE || true
+
+# mount the vm image and validate SCAP results
+sudo $base_dir/test-scap-results.sh $DISK_IMAGE

--- a/support/tests/media/qemu-test-live-iso.sh
+++ b/support/tests/media/qemu-test-live-iso.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+########
+# expect script to smoke test CLIP live ISO
+# by: booting ISO with qemu, logging in as toor,
+# and running shutdown
+
+
+usage() {
+  echo "usage: $0 ISO_PATH"
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+ISO_PATH="$1"
+
+if [ ! -e "$ISO_PATH" ]; then
+  usage
+  echo "missing ISO_PATH $ISO_PATH"
+  exit 1
+fi
+
+/usr/bin/expect -f - <<EOF
+set timeout 10
+
+spawn /usr/libexec/qemu-kvm -boot d -cdrom $ISO_PATH -m 512 -nographic -vga none -device sga
+
+send_user "waiting for boot menu\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "Press Tab for full configuration options on menu items" {
+    send_user "pressing tab to edit boot arguments\n"
+    send -- "	"
+  }
+}
+
+send_user "waiting to edit boot arguments\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "vmlinuz0" {
+    send_user "adding console=ttyS0 to boot arguments\n"
+    send -- " console=ttyS0\r"
+  }
+}
+
+set timeout 300
+send_user "waiting for login prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "login: " {
+    sleep 1
+    send_user "sending username\n"
+    send -- "toor\r"
+  }
+}
+
+set timeout 30
+send_user "waiting for password prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "Password: " {
+    sleep 1
+    send_user "sending password\n"
+    send -- "neutronbass\r"
+  }
+}
+
+send_user "waiting for command prompt\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "$ " {
+    send_user "sending shutdown command\n"
+    send -- "sudo shutdown -h now\r"
+  }
+}
+
+send_user "waiting for password request from sudo\n"
+expect {
+  default { send_user "\nerror: timeout or eof encountered\n"; exit 1 }
+  "password for toor:" {
+    sleep 1
+    send_user "sending password\n"
+    send -- "neutronbass\r"
+  }
+}
+
+set timeout 300
+send_user "waiting for power down\n"
+expect {
+  eof { send_user "got eof\n" }
+  timeout { send_user "\nerror: timeout while waiting for power off\n"; exit 1 }
+  "Powering off." { send_user "got powering off message\n" }
+}
+
+wait
+EOF
+

--- a/support/tests/media/test-scap-results.sh
+++ b/support/tests/media/test-scap-results.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# mount the vm disk image and check the scap results for failures
+
+set -e
+
+usage() {
+  echo "usage: $0 DISK_IMG"
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+DISK_IMAGE=$1
+
+if [ ! -e "$DISK_IMAGE" ]; then
+  echo "error: disk image $DISK_IMAGE does not exist"
+  exit 1
+fi
+
+MOUNT_DIR=vm_root
+is_mounted=0
+is_partxed=0
+
+cleanup() {
+  if [ -e "$MOUNT_DIR" ]; then
+    if [ "$is_mounted" = 1 ]; then
+      umount $MOUNT_DIR
+    fi
+    rmdir $MOUNT_DIR
+  fi
+
+  if [ -n "$vg_name" ]; then
+    vgchange -an $vg_name
+  fi
+
+  if [ "$is_partxed" = 1 ]; then
+    kpartx -d $DISK_IMAGE
+  fi
+}
+trap cleanup EXIT
+
+# create block devices for partions on vm image
+partitions=$(kpartx -v -s -a $DISK_IMAGE | awk '{print $3}')
+is_partxed=1
+sleep 2
+part_re=
+is_first=1
+for p in $partitions; do
+  if [ $is_first = 1 ]; then
+    is_first=0
+    part_re="/dev/mapper/$p"
+  else
+    part_re="$part_re|/dev/mapper/$p"
+  fi
+done
+
+mkdir $MOUNT_DIR
+vg_name=$(pvs -S "pv_name=~$part_re" -o vg_name --noheadings | awk '{print $1}')
+if [ -z "$vg_name" ]; then
+  echo "error: failed to find logical volume group in vm disk image"
+  exit 1
+fi
+mount /dev/$vg_name/root $MOUNT_DIR
+is_mounted=1
+
+scap_result_file=$MOUNT_DIR/root/scap/post/html/results.xml
+if [ ! -e $scap_result_file ]; then
+  echo "error: scap scan results do not exist"
+  exit 1
+else
+  bad_result_re='<result>\(error\|fail\|notchecked\)'
+  bad_result_count=$(grep -e "$bad_result_re" $scap_result_file | wc -l)
+  if [ $bad_result_count -gt 0 ]; then
+    grep -e "$bad_result_re" -B1 $scap_result_file
+    echo "error: scap scan reported $bad_result_count failures or errors"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
These scripts are far from perfect and are pretty fragile, but it is a start.

The following packages are needed:
qemu-kvm
qemu-kvm-common
expect
libvirt-client

To run a test build a live or install iso and run:
./support/tests/media/qemu-test-TYPE.sh ISO_PATH

where TYPE is live-iso or inst-iso
