### PR TITLE
Make SELinux policy Provide targeted etc.

### DIFF
--- a/packages/selinux-policy/selinux-policy7.3.spec
+++ b/packages/selinux-policy/selinux-policy7.3.spec
@@ -341,9 +341,10 @@ Group: System Environment/Base
 Requires(pre): policycoreutils >= %{POLICYCOREUTILSVER}
 Requires(pre): coreutils
 Requires(pre): selinux-policy = %{version}-%{release}
-Requires: selinux-policy = %{version}-%{release}
+Requires: selinux-policy = %{version}-%{release} policycoreutils-devel
 Conflicts:  audispd-plugins <= 1.7.7-1
 Conflicts:  seedit
+Provides: selinux-policy-targeted >= 3.13.1-39, selinux-policy-minimum >= 3.13.1-39, selinux-policy-mls >= 3.13.1-39
 Obsoletes: selinux-policy-targeted, selinux-policy-minimum, selinux-policy-mls 
 
 %description %{type}


### PR DESCRIPTION
Obsoletes and Provides have different meanings
based on the operation being performed, e.g.
an update vs install. To address both cases,
make our policy Provide all the policies it
obsoletes.