### PR TITLE
support faster development builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ MOCK_REL := rhel-$(RHEL_VER)-$(TARGET_ARCH)
 PKG_DIR += $(CURDIR)/packages
 
 #determine which variants we're building
-VARIANTS := $(filter %-inst-iso %-live-iso %-aws-ami,$(MAKECMDGOALS))
+VARIANTS := $(filter %-inst-iso %-inst-iso-fast %-live-iso %-aws-ami,$(MAKECMDGOALS))
+VARIANTS := $(subst -inst-iso-fast,,$(VARIANTS))
 VARIANTS := $(subst -inst-iso,,$(VARIANTS))
 VARIANTS := $(subst -aws-ami,,$(VARIANTS))
 VARIANTS := $(subst -live-iso,,$(VARIANTS))
@@ -192,6 +193,11 @@ SYSTEMS := $(shell find $(KICKSTART_DIR) -maxdepth 1 ! -name kickstart ! -name i
 # FIXME: remove when VPN is supported by CLIP for v7
 #LIVECDS := $(foreach SYSTEM,$(SYSTEMS),$(addsuffix -live-iso,$(SYSTEM)))
 LIVECDS := $(foreach SYSTEM,$(filter-out clip-vpn,$(SYSTEMS)),$(addsuffix -live-iso,$(SYSTEM)))
+
+# These are targets supported by the kickstart/Makefile that will be used to generate installation ISOs.
+# FIXME: remove when AWS is supported by CLIP for v7
+#FASTINSTISOS := $(foreach SYSTEM,$(SYSTEMS)),$(addsuffix -inst-iso-fast,$(SYSTEM)))
+FASTINSTISOS := $(foreach SYSTEM,$(filter-out clip-vpn,$(SYSTEMS)),$(addsuffix -inst-iso-fast,$(SYSTEM)))
 
 # These are targets supported by the kickstart/Makefile that will be used to generate installation ISOs.
 # FIXME: remove when AWS is supported by CLIP for v7
@@ -480,6 +486,11 @@ $(LIVECDS):  $(CONFIG_BUILD_DEPS) $(RPMS)
 	$(call MAKE_LIVE_TOOLS)
 	$(call MAKE_LORAX)
 	$(VERBOSE)OS_REL="$(call OS_REL)" $(MAKE) -f $(KICKSTART_DIR)/Makefile -C $(KICKSTART_DIR)/"`echo '$(@)'|$(SED) -e 's/\(.*\)-live-iso/\1/'`" live-iso
+
+PHONIES += $(FASTINSTISOS)
+$(FASTINSTISOS):  $(CONFIG_BUILD_DEPS) $(RPMS)
+	$(call CHECK_DEPS)
+	$(VERBOSE)OS_REL="$(call OS_REL)" $(MAKE) -f $(KICKSTART_DIR)/Makefile -C $(KICKSTART_DIR)/"`echo '$(@)'|$(SED) -e 's/\(.*\)-inst-iso-fast/\1/'`" iso-fast
 
 PHONIES += $(INSTISOS)
 $(INSTISOS):  $(CONFIG_BUILD_DEPS) $(RPMS)

--- a/kickstart/Makefile
+++ b/kickstart/Makefile
@@ -60,6 +60,9 @@ BUILD_DIR ?= $(TMP_DIR)/$(NAME)
 SUPPORT_DIR ?= $(ROOT_DIR)/support
 OUTPUT_DIR ?= $(ROOT_DIR)
 
+DEFAULT_DONOR_ISO := $(ROOT_DIR)/shell.iso
+DONOR_ISO ?= $(DEFAULT_DONOR_ISO)
+
 INST_KS := $(BUILD_DIR)/$(NAME).ks
 LIVE_KS := $(BUILD_DIR)/$(NAME)-live.ks
 AWS_KS  := $(BUILD_DIR)/$(NAME)-aws.ks
@@ -130,6 +133,16 @@ iso: $(DEPS) $(PUNGI) $(ADDTL_DEPS) setup-inst-ks check-volume-id
 	$(VERBOSE)sudo rm --force $(PUNGI_ISO_DIR)/$(NAME)-netinst-$(TARGET_ARCH)-$(ISO_VERSION).iso
 	$(VERBOSE)sudo mv --force $(PUNGI_ISO_DIR)/$(NAME)-*$(TARGET_ARCH)-$(ISO_VERSION).iso $(OUTPUT_DIR)/
 
+iso-fast: setup-inst-ks
+	@if [ ! -e "$(DONOR_ISO)" ]; then \
+		echo "error: DONOR_ISO $(DONOR_ISO) does not exist.  set DONOR_ISO to the path of an existing install iso or copy an existing iso to $(DEFAULT_DONOR_ISO)"; \
+		exit 1; \
+	fi
+	@echo "Repacking iso.  Do not use in production"
+	$(VERBOSE)rm -f $(ROOT_DIR)/$(NAME)-DVD-$(TARGET_ARCH)-$(ISO_VERSION)-fast.iso
+	$(VERBOSE)$(SUPPORT_DIR)/repack-iso.py $(DONOR_ISO) $(ROOT_DIR)/$(NAME)-DVD-$(TARGET_ARCH)-$(ISO_VERSION)-fast.iso \
+		$(SUPPORT_DIR)/update-inst-iso.sh $(INST_KS) $(PUNGI_OS_DIR)$(notdir $(INST_KS)) %ISO_ROOT
+
 live-iso: $(DEPS) $(ADDTL_DEPS) setup-live-ks
 	@echo "Live CD Creator needs root permissions - please enter your sudo password if prompted."
 	$(VERBOSE)cd $(BUILD_DIR);sudo $(RUN_LIVECD) $(LIVECD_PYTHONPATH) $(LIVECD_ARGS) --config="$(LIVE_KS)"
@@ -184,7 +197,7 @@ setup-aws-ks: $(SETUP_DEPS)
 	@echo "Modifying kickstart with build variables..."
 	$(VERBOSE)sed -i -e 's;#REPO-REPLACEMENT-PLACEHOLDER;$(REPO_LINES);' $(AWS_KS)
 	$(VERBOSE)sed -i -e 's;#CONFIG-BUILD-PLACEHOLDER;$(AWS_CONFIG_BUILD_BASH_VARS);' $(AWS_KS)
-	$(VERBOSE)sed -i -e 's;#CONFIG-BUILD-ADDTL-PACKAGES;$(shell echo "$(CONFIG_BUILD_ADDTL_PACKAGES)" | sed -e 's/ /\\n/g');' $(INST_KS)
+	$(VERBOSE)sed -i -e 's;#CONFIG-BUILD-ADDTL-PACKAGES;$(shell echo "$(CONFIG_BUILD_ADDTL_PACKAGES)" | sed -e 's/ /\\n/g');' $(AWS_KS)
 	$(FIX_KS_ENFORCING_MODE) $(AWS_KS)
 	$(VERBOSE)mkdir -p $(BUILD_DIR)/includes
 	$(VERBOSE)cp -a $(STATIC_INC) $(BUILD_DIR)/includes/

--- a/support/repack-iso.py
+++ b/support/repack-iso.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+'''
+Copyright (c) 2018 Quark Security, Inc. All rights reserved.
+Author: Marshall Miller <marshall@quarksecurity.com>
+'''
+
+import sys
+import os
+import tempfile
+import shutil
+import argparse
+import subprocess
+
+# run a command and return the stdout and stderr from the process
+def get_command_output(cmd):
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    rc = proc.wait()
+    if rc != 0:
+        raise Exception("command '%s' failed with rc %s" % (" ".join(cmd), rc))
+    return stdout, stderr
+
+# run a command
+def run_command(cmd, **kwargs):
+    proc = subprocess.Popen(cmd, **kwargs)
+    rc = proc.wait()
+    if rc != 0:
+        raise Exception("command '%s' failed with rc %s" % (" ".join(cmd), rc))
+
+# find the location of an executable
+def locate_executable(exe):
+    try:
+        loc, _ = get_command_output(["which", exe])
+        loc = loc.strip()
+        if not os.path.exists(loc):
+            raise Exception("failed to locate %s" % (exe,))
+    except Exception as e:
+        raise Exception("failed to locate %s: %s" % (exe, str(e)))
+
+    return loc
+
+# locate dependencies
+ISO_INFO = locate_executable("iso-info")
+MKISOFS = locate_executable("mkisofs")
+IMPLANTISOMD5 = locate_executable("implantisomd5")
+
+# class to help with modifying an existing iso
+class IsoRepacker(object):
+    def __init__(self, orig_iso_path, new_iso_path, command=None):
+        self.orig_iso_path = orig_iso_path
+        self.new_iso_path = new_iso_path
+        self.command = command
+
+        self.workdir = None
+        self.iso_mountpoint = None
+        self.extracted_dir = None
+        self.iso_mounted = False
+
+    def repack(self):
+        try:
+            self._setup()
+            self._unpack()
+            self._run_update_command()
+            self._pack()
+        except Exception as e:
+            self._cleanup()
+            print("error: %s" % (str(e),))
+            raise
+        self._cleanup()
+
+    def _get_orig_volname(self):
+        iso_info, _ = get_command_output([ISO_INFO, "-i", self.orig_iso_path])
+        for line in iso_info.split("\n"):
+            if "Volume" in line:
+                return line.split()[2]
+        raise Exception("failed to find the original volume name")
+
+    def _setup(self):
+        self.workdir = tempfile.mkdtemp(suffix='', prefix="isorepack-")
+
+        self.iso_mountpoint = os.path.join(self.workdir, "orig")
+        self.extracted_dir = os.path.join(self.workdir, "new")
+
+    def _cleanup(self):
+        if self.iso_mounted and self.iso_mountpoint:
+            run_command(["sudo", "umount", self.iso_mountpoint])
+            self.iso_mounted = False
+
+        if self.workdir and os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
+            self.workdir = None
+
+        self.iso_mountpoint = None
+        self.extracted_dir = None
+
+    def _unpack(self):
+        os.makedirs(self.iso_mountpoint)
+        run_command(["sudo", "mount", "-o", "loop", self.orig_iso_path, self.iso_mountpoint])
+        self.iso_mounted = True
+        shutil.copytree(self.iso_mountpoint, self.extracted_dir)
+
+    def _run_update_command(self):
+        if not self.command:
+            print("modify contents of iso rooted at %s and exit the shell to continue" % (self.extracted_dir,))
+            command = ["/bin/bash"]
+            env = {"PS1":r"[isorepack: \u@\h \W]\$ "}
+        else:
+            env = None
+            command = [self.command[0]]
+            for arg in self.command[1:]:
+                if arg == "%ISO_ROOT":
+                    command.append(self.extracted_dir)
+                else:
+                    command.append(arg)
+        run_command(command, env=env)
+
+    def _pack(self):
+        run_command([
+            MKISOFS,
+            "-f", "-v", "-U", "-J", "-R", "-T",
+            "-m", "repoview",
+            "-m", "boot.iso",
+            "-b", "isolinux/isolinux.bin",
+            "-c", "isolinux/boot.cat",
+            "-no-emul-boot",
+            "-boot-load-size", "4",
+            "-boot-info-table",
+            "-eltorito-alt-boot",
+            "-e", "images/efiboot.img",
+            "-no-emul-boot",
+            "-V", self._get_orig_volname(),
+            "-o", self.new_iso_path,
+            self.extracted_dir
+        ])
+        run_command([IMPLANTISOMD5, self.new_iso_path])
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("orig_iso", help="path to the original iso")
+    parser.add_argument("new_iso", help="path to output the new iso to")
+    parser.add_argument("command", nargs="*",
+        help="""optional command to be executed after the original
+              iso has been extracted and before the new iso is generated.  if
+              no command is supplied then an interactive shell will run to
+              allow manual modifications to the iso.  the output iso will
+              be generated when the interactive shell exits.  an argument of
+              %%ISO_ROOT will be replaced with the path to the extracted iso""")
+    args = parser.parse_args(argv)
+
+    if not os.path.exists(args.orig_iso):
+        print("error: the path supplied for the original iso does not exist")
+        return 1
+
+    if os.path.exists(args.new_iso):
+        print("error: the path supplied for the new iso already exists")
+        return 1
+
+    repacker = IsoRepacker(args.orig_iso, args.new_iso, args.command)
+    repacker.repack()
+
+    print("successfully created updated iso at %s" % (args.new_iso,))
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/support/update-inst-iso.sh
+++ b/support/update-inst-iso.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Copyright (c) 2018 Quark Security, Inc. All rights reserved.
+#Author: Marshall Miller <marshall@quarksecurity.com>
+set -x
+
+usage() {
+	echo "usage: $0 BUILDTIME_KS INSTALLTIME_KS ISO_ROOT"
+	echo "This script takes kickstarts and an extracted install iso as"
+	echo "inputs and modifies the install iso location by replacing"
+	echo "packages and kickstart and includes based on the supplied"
+	echo "kickstarts"
+	echo ""
+	echo "     BUILDTIME_KS     The path to the build-time variant of the"
+	echo "                      kickstart (e.g., tmp/clip-minimal/clip-minimal.ks)"
+	echo "     INSTALLTIME_KS   The path to the install-time variant of the"
+	echo "                      kickstart (e.g., tmp/clip-minimal/a759282/x86_64/os/clip-minimal.ks)"
+	echo "     ISO_ROOT         The path to the root directory of the extracted iso"
+}
+
+if [ "$#" -ne 3 ]; then
+	usage
+	exit 1
+fi
+
+BUILDTIME_KS="$1"
+INSTALLTIME_KS="$2"
+ISO_ROOT="$3"
+
+INCLUDES=$(dirname $INSTALLTIME_KS)/includes
+KICKSTART_PARSER=$(dirname "${BASH_SOURCE[0]}")/kickstart-parser.py
+REPOS_DIR=$(dirname "${BASH_SOURCE[0]}")/../repos/
+
+if [ ! -e "$BUILDTIME_KS" ]; then
+	echo "error: kickstart path $BUILDTIME_KS does not exist"
+	exit 1
+fi
+
+if [ ! -e "$INSTALLTIME_KS" ]; then
+	echo "error: kickstart path $INSTALLTIME_KS does not exist"
+	exit 1
+fi
+
+if [ ! -d "$ISO_ROOT" ]; then
+	echo "error: iso root $ISO_ROOT does not exist"
+	exit 1
+fi
+
+if [ ! -e "$INCLUDES" ]; then
+	echo "error: did not find kickstart includes directory at $INCLUDES"
+	exit 1
+fi
+
+# copy all packages
+rm -rf "$ISO_ROOT"/Packages/*
+$KICKSTART_PARSER "$BUILDTIME_KS" -o expected-packages
+grep -v -e '^#' expected-packages | while read p; do
+	find $REPOS_DIR -name $p.rpm -exec cp '{}' "$ISO_ROOT"/Packages/ \;
+done
+rm expected-packages
+
+# copy kickstart and includes
+cp "$INSTALLTIME_KS" "$ISO_ROOT"/
+cp "$INCLUDES"/* "$ISO_ROOT"/includes/
+
+# update the yum repo
+cd "$ISO_ROOT"
+# TODO: generate a new comps file rather than reusing the existing one
+COMPS_FILE=$(find repodata -name '*comps*.xml')
+createrepo -g $COMPS_FILE .


### PR DESCRIPTION
added targets and scripts to use an existing install iso to re-roll a
new one with updated packages and kickstart.  this must not be used
for production builds because the installation (anaconda) environment
and build/version information does not get updated.
to use copy an existing install iso to shell.iso and run
make VARIANT-inst-iso-fast